### PR TITLE
Fixed incorrect URL for installation in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimalistic wrapper to Mint.com API, designed to be a lean but functional mod
 
 ## Installation
 ```
-python -m pip install git+https://github.com/xinlu/yamintapi.git@master
+python -m pip install git+https://github.com/xinluh/yamintapi.git@master
 ```
 Or add to `requirements.txt` or `pyproject.toml` etc. depending on your package manager.
 


### PR DESCRIPTION
I spent way too long wondering why `pip install` was asking for a username and password.